### PR TITLE
Fix hex number highlighting when not preceded by space

### DIFF
--- a/PICO-8.tmLanguage
+++ b/PICO-8.tmLanguage
@@ -59,7 +59,7 @@
 			</dict>
 			<dict>
 				<key>match</key>
-				<string>(?&lt;![\d.])\s0x[a-fA-F\d]+|\b\d+(\.\d+)?([eE]-?\d+)?|\.\d+([eE]-?\d+)?</string>
+				<string>(?&lt;![\d.])\b0x[a-fA-F\d]+|\b\d+(\.\d+)?([eE]-?\d+)?|\.\d+([eE]-?\d+)?</string>
 				<key>name</key>
 				<string>constant.numeric.lua</string>
 			</dict>


### PR DESCRIPTION

The syntax definition file has bug which prevents hexadecimal numbers to be highlighted unless they are preceded by whitespace.  This patch fixes the issue by matching on word boundary instead of whitespace.

Before:
<img width="291" alt="screen shot 2017-03-04 at 11 32 14" src="https://cloud.githubusercontent.com/assets/31668/23578067/600cde3e-00ce-11e7-8461-17f8a1edcfee.png">

After:
<img width="296" alt="screen shot 2017-03-04 at 11 32 34" src="https://cloud.githubusercontent.com/assets/31668/23578070/6833319e-00ce-11e7-99d8-6f315b6f576c.png">

PS: awesome plugin! 👍 