### PR TITLE
Add comment start definition to fix "toggle comment" command

### DIFF
--- a/comments.tmPreferences
+++ b/comments.tmPreferences
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+   <key>name</key>
+   <string>Comments</string>
+   <key>scope</key>
+   <string>source.p8</string>
+   <key>settings</key>
+   <dict>
+      <key>shellVariables</key>
+      <array>
+         <dict>
+            <key>name</key>
+            <string>TM_COMMENT_START</string>
+            <key>value</key>
+            <string>-- </string>
+         </dict>
+      </array>
+   </dict>
+   <key>uuid</key>
+   <string>7ECB64D3-77C6-43B2-A105-555AFAE640B3</string>
+</dict>
+</plist>


### PR DESCRIPTION

This fixes the "toggle comment" command when editing .p8 files.