### PR TITLE
added setting pico-8_auto_lowercase to disable auto-lowercase

### DIFF
--- a/PICO-8.sublime-settings
+++ b/PICO-8.sublime-settings
@@ -8,5 +8,6 @@
 	"line_padding_bottom": 1,
 	"line_padding_top": 1,
 	"highlight_line": true,
-	"pico-8_path": "undefined"
+	"pico-8_path": "undefined",
+	"pico-8_auto_lowercase": true
 }

--- a/pico_on_save.py
+++ b/pico_on_save.py
@@ -11,4 +11,5 @@ class PicoOnSave(sublime_plugin.EventListener):
 	def on_pre_save(self, view):
 		syntax = view.settings().get("syntax")
 		if "PICO-8" in syntax:
-			view.run_command("pico_to_lower")
+			if view.settings().get("pico-8_auto_lowercase", True):
+				view.run_command("pico_to_lower")


### PR DESCRIPTION
Fixes #8

Add pico-8_auto_lowercase: false to your PICO-8 User settings to disable auto-lowercase on save.
Default is true to keep previous behavior. 