### PR TITLE
Don't lowercase _ENV or strings.

### DIFF
--- a/pico_on_save.py
+++ b/pico_on_save.py
@@ -3,9 +3,12 @@ import sublime_plugin
 
 class PicoToLower(sublime_plugin.TextCommand):
 	def run(self, edit):
-		upper = self.view.find_all("[A-Z]+")
+		upper = self.view.find_all("(_ENV)|([A-Z]+)")
 		for region in upper:
-			self.view.replace(edit, region, self.view.substr(region).lower())
+			s = self.view.substr(region)
+			if s == "_ENV" or self.view.score_selector(region.a, "string") > 0:
+				continue
+			self.view.replace(edit, region, s.lower())
 
 class PicoOnSave(sublime_plugin.EventListener):
 	def on_pre_save(self, view):


### PR DESCRIPTION
The special Lua table named _ENV is sometimes used in Pico-8 for various shenanigans. There are other special Lua tables with capitalized, case-sensitive names, but I don't know if any are widely used. But changing _ENV to _env inconvenienced me personally so I'm fixing that one. :)

Additionally, strings often deliberately contain uppercase characters, since they render as "puny font" in Pico-8. Lowercaseificaiton does more harm than good in a string context. If the syntax highlighting engine thinks we're in a string, do not tinker with case.